### PR TITLE
CDAP-15739. Integration tests for Google NLP Directives and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 Following is available in this repository. 
 
   * NLP Directives
+  * NLP Transform plugins
+
+# Running integration tests
+
+To run the tests the path to a service account key must be provided.
+The service account key can be found on the Dashboard in the Cloud Platform Console.
+Make sure the account key has permission to access Natural Language API.
+
+```
+mvn clean test -Dservice.account.file=<path-to-service-account-key-json>
+```
 
 # Contact
 
@@ -43,3 +54,4 @@ Cask is a trademark of Cask Data, Inc. All rights reserved.
 
 Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
 permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.
+

--- a/nlp-directives/src/test/java/io/cdap/google/directives/TestDirectives.java
+++ b/nlp-directives/src/test/java/io/cdap/google/directives/TestDirectives.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.google.directives;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.cdap.wrangler.api.RecipePipeline;
+import io.cdap.wrangler.api.Row;
+import io.cdap.wrangler.test.TestingRig;
+import io.cdap.wrangler.test.api.TestRecipe;
+import io.cdap.wrangler.test.api.TestRows;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Tests for the google nlp directives.
+ *
+ * To run the tests the path to a service account key must be provided.
+ * The service account key can be found on the Dashboard in the Cloud Platform Console.
+ * Make sure the account key has permission to access Natural Language API.
+ *
+ * mvn clean test -Dservice.account.file=<path-to-service-account-key-json>
+ *
+ */
+public class TestDirectives {
+  private static final Logger LOG = LoggerFactory.getLogger(TestDirectives.class);
+
+  private static final JsonParser PARSER = new JsonParser();
+  private static final String AUTHENTICATION_FILE = System.getProperty(
+    "service.account.file");
+
+  @BeforeClass
+  public static void initializeTests() {
+    try {
+      Assume.assumeNotNull(AUTHENTICATION_FILE);
+    } catch (AssumptionViolatedException e) {
+      LOG.warn("ETL tests are skipped. Please find the instructions on enabling it at " +
+                 "README.md");
+      throw e;
+    }
+  }
+
+  @Test
+  public void testAnalyzeSyntax() throws Exception {
+    String text = "Time is the indefinite continued progress of existence and events that occur in an apparently " +
+      "irreversible succession from the past, through the present, to the future.";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-analyze-syntax :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("sentences"));
+    Assert.assertTrue(jsonObject.has("tokens"));
+    Assert.assertTrue(jsonObject.has("language"));
+
+    Assert.assertEquals(1, jsonObject.getAsJsonArray("sentences").size());
+    Assert.assertEquals(text, jsonObject.getAsJsonArray("sentences").get(0).
+      getAsJsonObject().getAsJsonObject("text").getAsJsonPrimitive("content").getAsString());
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    // currently there is 29 tokens detected. Since response can change check that there are at least 5 tokens.
+    Assert.assertTrue(jsonObject.getAsJsonArray("tokens").size() > 5);
+  }
+
+  @Test
+  public void testAnalyzeEntities() throws Exception {
+    String text = "Washington is the 18th largest state, with an area of 71,362 square miles (184,827 square km).";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-analyze-entities :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("language"));
+    Assert.assertTrue(jsonObject.has("entities"));
+
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    // There are 5 entities: Washington ; area ; 71,362 ; 18 ; 184,827. Check that there are at least two since API
+    // results can change
+    Assert.assertTrue(jsonObject.getAsJsonArray("entities").size() > 1);
+  }
+
+  @Test
+  public void testAnalyzeSentiment() throws Exception {
+    String text = "This test is so awesome!";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-analyze-sentiment :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("language"));
+    Assert.assertTrue(jsonObject.has("sentences"));
+    Assert.assertTrue(jsonObject.has("documentSentiment"));
+
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    JsonObject documentSentiment = jsonObject.getAsJsonObject("documentSentiment");
+    Assert.assertTrue(documentSentiment.has("magnitude"));
+    Assert.assertTrue(documentSentiment.has("score"));
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("magnitude").isNumber());
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("score").isNumber());
+
+    Assert.assertEquals(1, jsonObject.getAsJsonArray("sentences").size());
+
+    JsonObject sentence = jsonObject.getAsJsonArray("sentences").get(0).getAsJsonObject();
+    Assert.assertEquals(text, sentence.getAsJsonObject("text").getAsJsonPrimitive("content").getAsString());
+    Assert.assertEquals(documentSentiment, sentence.getAsJsonObject("sentiment"));
+  }
+
+
+  @Test
+  public void testAnalyzeEntititySentiment() throws Exception {
+    String text = "This test is so awesome!";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-analyze-entity-sentiment :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("language"));
+    Assert.assertTrue(jsonObject.has("entities"));
+
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    // There is only one entity in the sentence "test".
+    Assert.assertTrue(jsonObject.getAsJsonArray("entities").size() > 0);
+
+    JsonObject entity = jsonObject.getAsJsonArray("entities").get(0).getAsJsonObject();
+    Assert.assertTrue(entity.has("name"));
+    Assert.assertTrue(entity.getAsJsonObject("sentiment").has("magnitude"));
+    Assert.assertTrue(entity.getAsJsonObject("sentiment").has("score"));
+  }
+
+  @Test
+  public void testClassifyText() throws Exception {
+    String text = "In physics, acceleration is the rate of change of velocity of an object with respect to time. " +
+      "An object's acceleration is the net result of all forces acting on the object, " +
+      "as described by Newton's Second Law.";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-classify-text :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("categories"));
+
+    Assert.assertTrue(jsonObject.getAsJsonArray("categories").size() > 0);
+    JsonObject category = jsonObject.getAsJsonArray("categories").get(0).getAsJsonObject();
+    Assert.assertTrue(StringUtils.containsIgnoreCase(category.getAsJsonPrimitive("name").getAsString(),
+                                                     "physics"));
+    Assert.assertTrue(category.getAsJsonPrimitive("confidence").isNumber());
+  }
+
+  @Test
+  public void testAnotateText() throws Exception {
+    String text = "A military is a heavily-armed, highly organised force primarily intended for warfare, also known " +
+      "collectively as armed forces. It is typically officially authorized and maintained by a sovereign state, " +
+      "with its members identifiable by their distinct military uniform.";
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-anotate-text :body :result '%s'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("sentences"));
+    Assert.assertTrue(jsonObject.has("tokens"));
+    Assert.assertTrue(jsonObject.has("entities"));
+    Assert.assertTrue(jsonObject.has("documentSentiment"));
+    Assert.assertTrue(jsonObject.has("language"));
+    Assert.assertTrue(jsonObject.has("categories"));
+
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    Assert.assertTrue(jsonObject.getAsJsonArray("categories").size() > 0);
+    JsonObject category = jsonObject.getAsJsonArray("categories").get(0).getAsJsonObject();
+    Assert.assertTrue(category.getAsJsonPrimitive("confidence").isNumber());
+
+    JsonObject documentSentiment = jsonObject.getAsJsonObject("documentSentiment");
+    Assert.assertTrue(documentSentiment.has("magnitude"));
+    Assert.assertTrue(documentSentiment.has("score"));
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("magnitude").isNumber());
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("score").isNumber());
+
+    // there are currently 7 entities
+    Assert.assertTrue(jsonObject.getAsJsonArray("entities").size() > 2);
+
+    JsonObject entity = jsonObject.getAsJsonArray("entities").get(0).getAsJsonObject();
+    Assert.assertTrue(entity.has("name"));
+    Assert.assertTrue(entity.getAsJsonObject("sentiment").has("magnitude"));
+    Assert.assertTrue(entity.getAsJsonObject("sentiment").has("score"));
+
+    Assert.assertEquals(2, jsonObject.getAsJsonArray("sentences").size());
+
+    JsonObject sentence = jsonObject.getAsJsonArray("sentences").get(0).getAsJsonObject();
+    Assert.assertTrue(text.contains(sentence.getAsJsonObject("text")
+                                      .getAsJsonPrimitive("content").getAsString()));
+
+    // currently there is 45 tokens detected. Since response can change check that there are at least 5 tokens.
+    Assert.assertTrue(jsonObject.getAsJsonArray("tokens").size() > 5);
+  }
+
+  @Test
+  public void testLanguageAndEncodingArguments() throws Exception {
+    String text = "I was really excited about visiting this place, and the mains were just fantastic, " +
+      "but the rest of the experience was really disappointing.";
+
+    TestRecipe recipe = new TestRecipe();
+
+    recipe.add(String.format("nlp-analyze-sentiment :body :result '%s' 'UTF8' 'en'", AUTHENTICATION_FILE));
+
+    TestRows rows = new TestRows();
+    rows.add(new Row("body", text));
+
+    RecipePipeline pipeline = TestingRig.pipeline(AnalyzeSyntax.class, recipe);
+    List<Row> actuals = pipeline.execute(rows.toList());
+    Assert.assertEquals(1, actuals.size());
+
+    JsonObject jsonObject = PARSER.parse(actuals.get(0).getValue("result").toString()).getAsJsonObject();
+    Assert.assertTrue(jsonObject.has("language"));
+    Assert.assertTrue(jsonObject.has("sentences"));
+    Assert.assertTrue(jsonObject.has("documentSentiment"));
+
+    Assert.assertEquals("en", jsonObject.getAsJsonPrimitive("language").getAsString());
+
+    JsonObject documentSentiment = jsonObject.getAsJsonObject("documentSentiment");
+    Assert.assertTrue(documentSentiment.has("magnitude"));
+    Assert.assertTrue(documentSentiment.has("score"));
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("magnitude").isNumber());
+    Assert.assertTrue(documentSentiment.getAsJsonPrimitive("score").isNumber());
+
+    Assert.assertEquals(1, jsonObject.getAsJsonArray("sentences").size());
+
+    JsonObject sentence = jsonObject.getAsJsonArray("sentences").get(0).getAsJsonObject();
+    Assert.assertEquals(text, sentence.getAsJsonObject("text").getAsJsonPrimitive("content").getAsString());
+    Assert.assertEquals(documentSentiment, sentence.getAsJsonObject("sentiment"));
+  }
+}

--- a/nlp-directives/src/test/java/io/cdap/google/directives/TestDirectives.java
+++ b/nlp-directives/src/test/java/io/cdap/google/directives/TestDirectives.java
@@ -48,16 +48,14 @@ public class TestDirectives {
   private static final Logger LOG = LoggerFactory.getLogger(TestDirectives.class);
 
   private static final JsonParser PARSER = new JsonParser();
-  private static final String AUTHENTICATION_FILE = System.getProperty(
-    "service.account.file");
+  private static final String AUTHENTICATION_FILE = System.getProperty("service.account.file");
 
   @BeforeClass
   public static void initializeTests() {
     try {
       Assume.assumeNotNull(AUTHENTICATION_FILE);
     } catch (AssumptionViolatedException e) {
-      LOG.warn("ETL tests are skipped. Please find the instructions on enabling it at " +
-                 "README.md");
+      LOG.warn("ETL tests are skipped. Please find the instructions on enabling it at README.md");
       throw e;
     }
   }

--- a/nlp-plugins/src/test/java/io/cdap/google/plugins/NLPTransformTest.java
+++ b/nlp-plugins/src/test/java/io/cdap/google/plugins/NLPTransformTest.java
@@ -1,0 +1,254 @@
+/*
+ *  Copyright © 2019 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.google.plugins;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.mock.common.MockEmitter;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Tests for the google nlp transform plugins.
+ *
+ * To run the tests the path to a service account key must be provided.
+ * The service account key can be found on the Dashboard in the Cloud Platform Console.
+ * Make sure the account key has permission to access Natural Language API.
+ *
+ * mvn clean test -Dservice.account.file=<path-to-service-account-key-json>
+ *
+ */
+public class NLPTransformTest {
+  private static final Logger LOG = LoggerFactory.getLogger(NLPTransformTest.class);
+
+  private static final String AUTHENTICATION_FILE = System.getProperty("service.account.file");
+
+  private static final String ERROR_SCHEMA_BODY_PROPERTY = "body";
+  private static final Schema INPUT_SCHEMA = Schema.recordOf("stringInput",
+                                                                    Schema.Field.of(ERROR_SCHEMA_BODY_PROPERTY,
+                                                                                    Schema.of(Schema.Type.STRING)));
+
+  @BeforeClass
+  public static void initializeTests() {
+    try {
+      Assume.assumeNotNull(AUTHENTICATION_FILE);
+    } catch (AssumptionViolatedException e) {
+      LOG.warn("ETL tests are skipped. Please find the instructions on enabling it at " +
+                 "README.md");
+      throw e;
+    }
+  }
+
+  @Test
+  public void testAnalyzeSyntax() {
+    String text = "Time is the indefinite continued progress of existence and events that occur in an apparently " +
+      "irreversible succession from the past, through the present, to the future.";
+
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnalyzeSyntaxTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    List<StructuredRecord> sentences = result.get("sentences");
+    List<StructuredRecord> tokens = result.get("tokens");
+
+    Assert.assertEquals(1, sentences.size());
+    Assert.assertEquals(text, sentences.get(0).get("content"));
+    Assert.assertEquals("en", result.get("language"));
+
+    // currently there is 29 tokens detected. Since response can change check that there are at least 5 tokens.
+    Assert.assertTrue(tokens.size() > 5);
+  }
+
+  @Test
+  public void testAnalyzeEntities() {
+    String text = "Washington is the 18th largest state, with an area of 71,362 square miles (184,827 square km).";
+
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnalyzeEntitiesTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    Assert.assertEquals("en", result.get("language"));
+
+    List<StructuredRecord> entities = result.get("entities");
+
+    // There are 5 entities: Washington ; area ; 71,362 ; 18 ; 184,827. Check that there are at least two since API
+    // results can change
+    Assert.assertTrue(entities.size() > 1);
+  }
+
+  @Test
+  public void testAnalyzeSentiment() {
+    String text = "This test is so awesome!";
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnalyzeSentimentTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    List<StructuredRecord> sentences = result.get("sentences");
+
+    Assert.assertEquals("en", result.get("language"));
+
+    Assert.assertTrue(result.get("magnitude") instanceof Number);
+    Assert.assertTrue(result.get("score") instanceof Number);
+
+    Assert.assertEquals(1, sentences.size());
+    Assert.assertEquals(text, sentences.get(0).get("content"));
+  }
+
+  @Test
+  public void testAnalyzeEntititySentiment() {
+    String text = "This test is so awesome!";
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body",  null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnalyzeEntitySentimentTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    Assert.assertEquals("en", result.get("language"));
+
+    List<StructuredRecord> entities = result.get("entities");
+    // There is only one entity in the sentence "test".
+    Assert.assertTrue(entities.size() > 0);
+
+    StructuredRecord entity = entities.get(0);
+    Assert.assertTrue(entity.get("name") instanceof String);
+    Assert.assertTrue(entity.get("magnitude") instanceof Number);
+    Assert.assertTrue(entity.get("score") instanceof Number);
+  }
+
+  @Test
+  public void testClassifyText() {
+    String text = "In physics, acceleration is the rate of change of velocity of an object with respect to time. " +
+      "An object's acceleration is the net result of all forces acting on the object, " +
+      "as described by Newton's Second Law.";
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new ClassifyContentTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+    List<StructuredRecord> categories = result.get("categories");
+
+    Assert.assertTrue(categories.size() > 0);
+    StructuredRecord category = categories.get(0);
+    Assert.assertTrue(StringUtils.containsIgnoreCase(category.get("name").toString(), "physics"));
+    Assert.assertTrue(category.get("confidence") instanceof Number);
+  }
+
+  @Test
+  public void testAnotateText() {
+    String text = "A military is a heavily-armed, highly organised force primarily intended for warfare, also known " +
+      "collectively as armed forces. It is typically officially authorized and maintained by a sovereign state, " +
+      "with its members identifiable by their distinct military uniform.";
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", null, null,
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnotateTextTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    List<StructuredRecord> sentences = result.get("sentences");
+    List<StructuredRecord> tokens = result.get("tokens");
+    List<StructuredRecord> entities = result.get("entities");
+    List<StructuredRecord> categories = result.get("categories");
+
+    Assert.assertEquals("en", result.get("language"));
+
+    Assert.assertTrue(categories.size() > 0);
+    StructuredRecord category = categories.get(0);
+    Assert.assertTrue(category.get("confidence") instanceof Number);
+
+    Assert.assertTrue(result.get("magnitude") instanceof Number);
+    Assert.assertTrue(result.get("score") instanceof Number);
+
+    // there are currently 7 entities
+    Assert.assertTrue(entities.size() > 2);
+
+    StructuredRecord entity = entities.get(0);
+    Assert.assertTrue(entity.get("name") instanceof String);
+    Assert.assertTrue(entity.get("magnitude") instanceof Number);
+    Assert.assertTrue(entity.get("score") instanceof Number);
+
+    Assert.assertEquals(2, sentences.size());
+
+    Assert.assertTrue(text.contains(sentences.get(0).get("content").toString()));
+
+    // currently there is 45 tokens detected. Since response can change check that there are at least 5 tokens.
+    Assert.assertTrue(tokens.size() > 5);
+  }
+
+  @Test
+  public void testLanguageAndEncodingArguments() {
+    String text = "I was really excited about visiting this place, and the mains were just fantastic, " +
+      "but the rest of the experience was really disappointing.";
+
+    StructuredRecord record = StructuredRecord.builder(INPUT_SCHEMA).set("body", text).build();
+    NLPConfig config = new NLPConfig("body", "UTF8", "en",
+                                     "stopOnError", AUTHENTICATION_FILE);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+
+    NLPTransform transform = new AnalyzeSentimentTransform(config);
+    transform.transform(record, emitter);
+
+    StructuredRecord result = emitter.getEmitted().get(0);
+
+    List<StructuredRecord> sentences = result.get("sentences");
+
+    Assert.assertEquals("en", result.get("language"));
+
+    Assert.assertTrue(result.get("magnitude") instanceof Number);
+    Assert.assertTrue(result.get("score") instanceof Number);
+
+    Assert.assertEquals(1, sentences.size());
+    Assert.assertEquals(text, (sentences.get(0)).get("content"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,14 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Regarding the transform plugins integration tests:
I tried to create ETL tests. But there is a dependency problem which I don't think can be solved. Basically Google NLP depends on guava 28.0-android, while CDAP depends to guava 13.0.
If I just exclude any of guavas, calls in either google nlp or in CDAP fail, due to method not found.

Also since transform plugins basically use only a transform method and nothing else, these tests does not lack much coverage.